### PR TITLE
Treat URL env var when getting lighthouse link

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -19,7 +19,7 @@ _log "║ Average of ${C_WHT}${RUNS}${C_END} RUNS and ${C_WHT}${urls_length}${C_
 _log "╚══════════════════════════════╝"
 
 for url in ${URLS[@]}; do 
-    lighthouse_link=$(jq -r ".\"${url}\"" <<< ${LINKS})
+    lighthouse_link=$(jq -r ".\"${url%/}/\"" <<< ${LINKS})
 
     ## Summary (AVG)
     list_summary_name=(performance accessibility "best-practices" seo pwa)


### PR DESCRIPTION
### What?
- Treat URL env var to get the lighthouse link considering a trailing slash at the end of his value.

### Why?
- Because TreoSh action alway put the trailing slash at the end of urls in LINKS output.

---
So, if the url is `http://localhost`, the action set the output with the value:
```json
{
    "http://localhost/": "https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1678374798202-12345.report.html"
}
```