### PR TITLE
Setup Node.js to make sure it's the correct version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,11 @@ runs:
         source scripts/utils.sh
         _set_up_lhci_env_vars ${{ inputs.collect_preset }}
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
     - name: Treosh Lighthouse CI Action
       id: treosh-lhci-action
       uses: treosh/lighthouse-ci-action@v9


### PR DESCRIPTION
Sometimes someone can make the setup-node of an incompatible version, so we need to guarantee version 18 to run the action